### PR TITLE
Add transaction logging for expired contract payouts

### DIFF
--- a/src/main/java/com/appdev/allin/Application.java
+++ b/src/main/java/com/appdev/allin/Application.java
@@ -6,6 +6,8 @@ import com.appdev.allin.player.PlayerRepo;
 import com.appdev.allin.playerData.PlayerDataRepo;
 import com.appdev.allin.user.User;
 import com.appdev.allin.user.UserService;
+import com.appdev.allin.transaction.Transaction;
+import com.appdev.allin.transaction.TransactionService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,6 +32,9 @@ public class Application {
     @Autowired
     UserService userService;
 
+    @Autowired
+    TransactionService transactionService;
+
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
@@ -45,6 +50,8 @@ public class Application {
                 if (isContractHit(contract)) {
                     processPayout(contract);
                 }
+
+                createFinalTransaction(contract);
 
                 contract.setExpired(true);
                 contractRepo.save(contract);
@@ -64,5 +71,17 @@ public class Application {
             Integer payoutAmount = contract.getValue();
             userService.addToUserBalance(owner, payoutAmount);
         }
+    }
+
+    private void createFinalTransaction(Contract contract) {
+        User seller = contract.getOwner();
+        Transaction finalTransaction = new Transaction(
+            seller,
+            null,
+            contract,
+            LocalDateTime.now(),
+            contract.getValue()
+        );
+        transactionService.createTransaction(finalTransaction);
     }
 }

--- a/src/main/java/com/appdev/allin/Application.java
+++ b/src/main/java/com/appdev/allin/Application.java
@@ -12,14 +12,21 @@ import com.appdev.allin.transaction.TransactionService;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import org.springframework.scheduling.annotation.Scheduled;
 
+@EnableScheduling
 @SpringBootApplication
 public class Application {
+
+    private static final Logger logger = LoggerFactory.getLogger(Application.class);
+
     @Autowired
     PlayerRepo playerRepo;
 
@@ -42,6 +49,8 @@ public class Application {
     // Once a day at midnight
     @Scheduled(cron = "0 0 0 * * *")
     public void checkAndProcessContracts() {
+        logger.info("Running scheduled contract check at {}", LocalDateTime.now());
+
         List<Contract> contracts = contractRepo.findAll();
         for (Contract contract : contracts) {
             if (!contract.getExpired() &&

--- a/src/test/java/com/appdev/allin/ExpiredContractPayoutTest.java
+++ b/src/test/java/com/appdev/allin/ExpiredContractPayoutTest.java
@@ -1,96 +1,105 @@
-// package com.appdev.allin;
+package com.appdev.allin;
 
-// import static org.mockito.Mockito.doReturn;
-// import static org.mockito.Mockito.when;
-// import static org.mockito.Mockito.spy;
-// import static org.mockito.Mockito.verify;
-// import static org.mockito.Mockito.times;
-// import static org.mockito.ArgumentMatchers.anyInt;
-// import static org.mockito.ArgumentMatchers.anyDouble;
-// import static org.junit.jupiter.api.Assertions.assertTrue;
-// import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyDouble;
+import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-// import org.junit.jupiter.api.BeforeEach;
-// import org.junit.jupiter.api.Test;
-// import org.mockito.InjectMocks;
-// import org.mockito.Mock;
-// import org.mockito.MockitoAnnotations;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
-// import java.time.LocalDate;
-// import java.util.Arrays;
+import java.time.LocalDateTime;
+import java.util.Arrays;
 
-// import com.appdev.allin.contract.Contract;
-// import com.appdev.allin.user.User;
-// import com.appdev.allin.contract.ContractRepo;
-// import com.appdev.allin.factories.ContractFactory;
-// import com.appdev.allin.factories.UserFactory;
-// import com.appdev.allin.user.UserService;
+import com.appdev.allin.contract.Contract;
+import com.appdev.allin.user.User;
+import com.appdev.allin.contract.ContractRepo;
+import com.appdev.allin.factories.ContractFactory;
+import com.appdev.allin.factories.UserFactory;
+import com.appdev.allin.transaction.TransactionService;
+import com.appdev.allin.user.UserService;
+import com.appdev.allin.transaction.Transaction;
 
-// public class ExpiredContractPayoutTest {
+public class ExpiredContractPayoutTest {
 
-// @Mock
-// private ContractRepo contractRepo;
+@Mock
+private ContractRepo contractRepo;
 
-// @Mock
-// private UserService userService;
+@Mock
+private UserService userService;
 
-// @InjectMocks
-// private Application application;
+@Mock
+private TransactionService transactionService;
 
-// private ContractFactory contractFactory;
-// private User owner;
-// private Contract expiredContract;
-// private Contract unexpiredContract;
 
-// @BeforeEach
-// public void setUp() {
-// MockitoAnnotations.openMocks(this);
+@InjectMocks
+private Application application;
 
-// // Initialize the factory
-// contractFactory = new ContractFactory();
+private ContractFactory contractFactory;
+private User owner;
+private Contract expiredContract;
+private Contract unexpiredContract;
 
-// // Create a random user using UserFactory
-// owner = UserFactory.createRandomUser();
-// owner.setId(1); // Set an ID for testing consistency
+@BeforeEach
+public void setUp() {
+MockitoAnnotations.openMocks(this);
 
-// // Create contracts using the factory
-// expiredContract = contractFactory.createRandomContract(owner);
-// expiredContract.setExpirationTime(expiredContract.getCreationTime().plusDays(-10));
-// // Already expired
-// expiredContract.setExpired(false); // Not yet marked expired
-// expiredContract.setValue(200.0); // Payout value
+// Initialize the factory
+contractFactory = new ContractFactory();
 
-// unexpiredContract = contractFactory.createRandomContract(owner);
-// unexpiredContract.setExpirationTime(LocalDate.now().plusDays(30)); // Not
-// expired yet
-// unexpiredContract.setExpired(false);
+// Create a random user using UserFactory
+owner = UserFactory.createRandomUser();
+owner.setUid("test-user-1"); // Set an ID for testing consistency
 
-// // Mock contract repository to return the contracts
-// when(contractRepo.findAll()).thenReturn(Arrays.asList(expiredContract,
-// unexpiredContract));
-// }
+// Create contracts using the factory
+expiredContract = contractFactory.createRandomContract(owner);
+expiredContract.setExpirationTime(expiredContract.getCreationTime().plusDays(-10));
 
-// @Test
-// public void testExpiredContractPayout() {
-// // Mock isContractHit to return true only for the expired contract
-// Application appSpy = spy(application);
-// doReturn(true).when(appSpy).isContractHit(expiredContract);
-// doReturn(false).when(appSpy).isContractHit(unexpiredContract);
+// Already expired contract
+expiredContract.setExpired(false); // Not yet marked expired
+expiredContract.setValue(200); // Payout value
 
-// // Run the checkAndProcessContracts method
-// appSpy.checkAndProcessContracts();
+// Unexpired contract
+unexpiredContract = contractFactory.createRandomContract(owner);
+unexpiredContract.setExpirationTime(LocalDateTime.now().plusDays(30));
+unexpiredContract.setExpired(false);
 
-// // Verify that the expired contract was processed
-// verify(userService).addToUserBalance(owner.getId(), 200.0); // Ensure payout
-// matches contract value
-// assertTrue(expiredContract.getExpired()); // Contract should be marked as
-// expired
+// Mock contract repository to return the contracts
+when(contractRepo.findAll()).thenReturn(Arrays.asList(expiredContract,
+unexpiredContract));
+}
 
-// // Verify that the unexpired contract was not processed
-// verify(userService, times(1)).addToUserBalance(anyInt(), anyDouble()); //
-// Ensure only one payout
-// assertFalse(unexpiredContract.getExpired()); // Unexpired contract should
-// remain unexpired
-// }
+@Test
+public void testExpiredContractPayout() {
+    Application appSpy = spy(application);
 
-// }
+    // Make sure contractRepo returns both contracts
+    when(contractRepo.findAll()).thenReturn(Arrays.asList(expiredContract, unexpiredContract));
+
+    // Mock isContractHit
+    doReturn(true).when(appSpy).isContractHit(expiredContract);
+    doReturn(false).when(appSpy).isContractHit(unexpiredContract);
+
+    // Run logic
+    appSpy.checkAndProcessContracts();
+
+    // Verify payout was processed
+    verify(userService, times(1)).addToUserBalance(owner, 200);
+
+    // Verify transaction was created
+    verify(transactionService, times(1)).createTransaction(any(Transaction.class));
+
+    // Verify expiration flags
+    assertTrue(expiredContract.getExpired());
+    assertFalse(unexpiredContract.getExpired());
+}
+}


### PR DESCRIPTION
## Overview

This PR adds logic to log a final transaction when a contract expires.

## Changes Made

Create a new transaction when a contract expires.

## Test Coverage

Updated `ExpiredContractPayoutTest` to verify that a transaction is created when a contract expires.

